### PR TITLE
Implement flexible amount parser

### DIFF
--- a/src/app/home/page.jsx
+++ b/src/app/home/page.jsx
@@ -16,7 +16,8 @@ export default function FoodNLPPage() {
   const analyzeInput = (val) => {
     const matches = fuzzyFind(foodList, val);
     setSuggestions(matches);
-    const amt = extractAmount(val);
+    const portion = matches && matches.length ? matches[0].portion : 100;
+    const amt = extractAmount(val, portion);
     setAmount(amt);
     if (matches && matches.length) {
       setResult(matches[0]);


### PR DESCRIPTION
## Summary
- parse portions, grams and kilos with keywords
- adjust analyzer usage to include portion size

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68599451c2c4832fb4db66d0fa9c5c3c