### PR TITLE
Improve amount extraction logic

### DIFF
--- a/src/app/home/page.jsx
+++ b/src/app/home/page.jsx
@@ -16,7 +16,8 @@ export default function FoodNLPPage() {
   const analyzeInput = (val) => {
     const matches = fuzzyFind(foodList, val);
     setSuggestions(matches);
-    const amt = extractAmount(val);
+    const portion = matches && matches.length ? matches[0].portion || 100 : 100;
+    const amt = extractAmount(val, portion);
     setAmount(amt);
     if (matches && matches.length) {
       setResult(matches[0]);

--- a/test/analyzer.test.mjs
+++ b/test/analyzer.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { fuzzyFind } from '../src/app/home/analyzer.js';
+import { fuzzyFind, extractAmount } from '../src/app/home/analyzer.js';
 
 const foodList = [
   { name: 'Tavuk Göğsü' },
@@ -18,4 +18,24 @@ test('phrase with extra word içtim matches tavuk göğsü', () => {
   const matches = fuzzyFind(foodList, 'tavuk göğüsü içtim');
   assert.ok(matches.length > 0, 'no matches returned');
   assert.equal(matches[0].name, 'Tavuk Göğsü');
+});
+
+test('3 adet with portion 90 returns 270 grams', () => {
+  const grams = extractAmount('3 adet tavuk', 90);
+  assert.equal(grams, 270);
+});
+
+test('200gram returns 200 grams', () => {
+  const grams = extractAmount('200gram tavuk');
+  assert.equal(grams, 200);
+});
+
+test('yarım kg returns 500 grams', () => {
+  const grams = extractAmount('yarım kg pirinç');
+  assert.equal(grams, 500);
+});
+
+test('1/2 paket with portion 100 returns 50 grams', () => {
+  const grams = extractAmount('1/2 paket bisküvi', 100);
+  assert.equal(grams, 50);
 });


### PR DESCRIPTION
## Summary
- implement new rules for amount parsing supporting portion keywords, grams and kilograms
- use updated extraction in `FoodNLPPage`
- add unit tests for amount extraction

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a39f420e8832fa6ebe2c521855e57