### PR TITLE
Improve amount parser

### DIFF
--- a/src/app/home/page.jsx
+++ b/src/app/home/page.jsx
@@ -16,7 +16,8 @@ export default function FoodNLPPage() {
   const analyzeInput = (val) => {
     const matches = fuzzyFind(foodList, val);
     setSuggestions(matches);
-    const amt = extractAmount(val);
+    const portion = matches && matches.length ? matches[0].portion : 100;
+    const amt = extractAmount(val, portion);
     setAmount(amt);
     if (matches && matches.length) {
       setResult(matches[0]);
@@ -46,6 +47,8 @@ export default function FoodNLPPage() {
   }
 
   function handleSelect(item) {
+    const amt = extractAmount(input, item.portion);
+    setAmount(amt);
     setResult(item);
     setInput(item.name);
     setSuggestions([]);

--- a/test/analyzer.test.mjs
+++ b/test/analyzer.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { fuzzyFind } from '../src/app/home/analyzer.js';
+import { fuzzyFind, extractAmount } from '../src/app/home/analyzer.js';
 
 const foodList = [
   { name: 'Tavuk Göğsü' },
@@ -18,4 +18,21 @@ test('phrase with extra word içtim matches tavuk göğsü', () => {
   const matches = fuzzyFind(foodList, 'tavuk göğüsü içtim');
   assert.ok(matches.length > 0, 'no matches returned');
   assert.equal(matches[0].name, 'Tavuk Göğsü');
+});
+
+test('extractAmount handles portion keywords', () => {
+  const grams = extractAmount('3 adet elma', 90);
+  assert.equal(grams, 270);
+});
+
+test('extractAmount handles gram keywords without space', () => {
+  assert.equal(extractAmount('200gram tavuk'), 200);
+});
+
+test('extractAmount handles kilogram with fraction', () => {
+  assert.equal(extractAmount('1/2 kg et'), 500);
+});
+
+test('extractAmount handles yarım keyword', () => {
+  assert.equal(extractAmount('yarım dilim kek', 80), 40);
 });


### PR DESCRIPTION
## Summary
- interpret amounts in grams, kilograms or portions
- update page to pass portion to amount parser
- test for new amount parser cases

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a85d24060832fa58abcca3f145dda