### PR TITLE
Show user info on pages and fix auth endpoints

### DIFF
--- a/src/app/[username]/[recordName]/page.jsx
+++ b/src/app/[username]/[recordName]/page.jsx
@@ -22,5 +22,12 @@ export default function RecordPage({ params }) {
   if (loading) return <div className="text-center p-8">Yükleniyor...</div>;
   if (!authorized) return <div className="text-center p-8">Erişim hatası</div>;
 
-  return <WordEditor />;
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold mb-4 text-center">
+        {username} / {recordName}
+      </h1>
+      <WordEditor />
+    </div>
+  );
 }

--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -10,7 +10,7 @@ export default function LoginPage() {
 
   function handleSubmit(e) {
     e.preventDefault();
-    fetch(`${baseUrl}/api/auth/login`, {
+    fetch(`${baseUrl}/api/users/login`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, password }),

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -40,7 +40,10 @@ export default function Home() {
 
   return (
     <div className="max-w-2xl mx-auto p-4">
-      <h1 className="text-2xl font-bold mb-4 text-center">PerhizApp</h1>
+      <h1 className="text-2xl font-bold mb-2 text-center">PerhizApp</h1>
+      {username && (
+        <p className="text-center mb-2">Hoş geldin, {username}!</p>
+      )}
       <p className="mb-6 text-center">
         Kişisel diyet kayıtlarınızı tutabileceğiniz basit bir uygulama.
       </p>

--- a/src/app/signup/page.jsx
+++ b/src/app/signup/page.jsx
@@ -10,7 +10,7 @@ export default function SignUpPage() {
 
   function handleSubmit(e) {
     e.preventDefault();
-    fetch(`${baseUrl}/api/auth/signup`, {
+    fetch(`${baseUrl}/api/users/signup`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, password }),


### PR DESCRIPTION
## Summary
- update login to send POST to `/api/users/login`
- update signup to send POST to `/api/users/signup`
- display logged-in username on the home page
- show username and record name on the record page
- confirm dynamic `[username]/[recordName]` route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c4c012e94832f993b3a7a1f62c186