### PR TITLE
Add record API integration

### DIFF
--- a/src/app/[username]/[recordName]/page.jsx
+++ b/src/app/[username]/[recordName]/page.jsx
@@ -1,105 +1,71 @@
 "use client";
-import React from "react";
-import { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import WordEditor from "@/components/WordEditor";
 
 export default function RecordPage({ params }) {
-  // Unwrap params using React.use for Next.js 14+ compatibility
   const { username, recordName } = React.use(params);
-  const [authorized, setAuthorized] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [record, setRecord] = useState({
-    username,
-    records: [
-      {
-        recordName,
-        entries: [],
-      },
-    ],
-  });
   const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
+  const [loading, setLoading] = useState(true);
+  const [foods, setFoods] = useState("");
+  const [data, setData] = useState("");
+  const [total, setTotal] = useState("");
   const saveTimeout = useRef();
 
-  // Kayıt verisini backend'den çek
+  // Fetch record on mount
   useEffect(() => {
-    fetch(`${baseUrl}/api/users/getHistory?username=${username}`)
+    fetch(`${baseUrl}/api/records/getRecord?username=${username}&recordName=${recordName}`)
       .then((res) => res.json())
-      .then((data) => {
-        const rec = (data.records || []).find((r) => r.recordName === recordName);
-        if (rec) {
-          setRecord({ username, records: [rec] });
-        }
-        setAuthorized(true);
+      .then((rec) => {
+        setFoods(rec.foods || "");
+        setData(rec.data || "");
+        setTotal(rec.total || "");
       })
-      .catch(() => setAuthorized(false))
       .finally(() => setLoading(false));
   }, [baseUrl, username, recordName]);
 
-  // Backend'den gelen kayıtları tümüyle al
+  // Autosave when content changes
   useEffect(() => {
-    fetch(`${baseUrl}/api/users/getHistory?username=${username}`)
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.records) {
-          setRecord({ username, records: data.records });
-        }
-        setAuthorized(true);
-      })
-      .catch(() => setAuthorized(false))
-      .finally(() => setLoading(false));
-  }, [baseUrl, username, recordName]);
-
-  // Yeni perhiz kaydı ekle fonksiyonu
-  function addNewRecord(newRecord) {
-    setRecord((prev) => ({
-      ...prev,
-      records: [...prev.records, newRecord],
-    }));
-  }
-
-  // Otomatik kaydetme (debounce)
-  useEffect(() => {
-    if (!authorized) return;
+    if (loading) return;
     if (saveTimeout.current) clearTimeout(saveTimeout.current);
     saveTimeout.current = setTimeout(() => {
-      fetch(`${baseUrl}/api/users/putHistory`, {
+      fetch(`${baseUrl}/api/records/postRecord`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(record),
+        body: JSON.stringify({ username, recordName, foods, data, total }),
       });
-    }, 5000); // 5 saniye sonra kaydet
+    }, 5000);
     return () => clearTimeout(saveTimeout.current);
-  }, [record, authorized, baseUrl]);
+  }, [foods, data, total, username, recordName, baseUrl, loading]);
 
-  // Sayfa kapatılırken kaydet
+  // Save when leaving page
   useEffect(() => {
-    function handleBeforeUnload() {
-      navigator.sendBeacon(
-        `${baseUrl}/api/users/putHistory`,
-        new Blob([JSON.stringify(record)], { type: "application/json" })
-      );
+    function handleUnload() {
+      const blob = new Blob([
+        JSON.stringify({ username, recordName, foods, data, total })
+      ], { type: "application/json" });
+      navigator.sendBeacon(`${baseUrl}/api/records/postRecord`, blob);
     }
-    window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [record, baseUrl]);
+    window.addEventListener("beforeunload", handleUnload);
+    return () => window.removeEventListener("beforeunload", handleUnload);
+  }, [foods, data, total, username, recordName, baseUrl]);
 
-  if (loading) return <div className="text-center p-8">Yükleniyor...</div>;
-  if (!authorized) return <div className="text-center p-8">Erişim hatası</div>;
+  if (loading) return <div className="p-8 text-center">Yükleniyor...</div>;
 
   return (
     <div className="p-4">
       <h1 className="text-xl font-semibold mb-4 text-center">
-        {username} / Kayıtlar
+        {username} / {recordName}
       </h1>
-      <ul className="mb-6">
-        {record.records.map((rec, idx) => (
-          <li key={rec.recordName + idx} className="border rounded p-3 mb-2">
-            <div className="font-bold">{rec.recordName}</div>
-            <div className="text-xs text-gray-500">{rec.entries.length} giriş</div>
-          </li>
-        ))}
-      </ul>
-      <WordEditor addNewRecord={addNewRecord} />
+      <WordEditor
+        initialText={foods}
+        initialResults={data}
+        initialTotal={total}
+        onChange={({ foods: f, data: d, total: t }) => {
+          setFoods(f);
+          setData(d);
+          setTotal(t);
+        }}
+      />
     </div>
   );
 }

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -11,29 +11,12 @@ export default function Home() {
   const [username, setUsername] = useState("");
   const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
 
-  function getAuthHeader() {
-    const username = localStorage.getItem("username") || "";
-    const password = localStorage.getItem("password") || "";
-    if (!username || !password) return {};
-    const encoded = btoa(`${username}:${password}`);
-    return { Authorization: `Basic ${encoded}` };
-  }
-
   function fetchHistory() {
-    fetch(`${baseUrl}/api/users/getHistory`, {
-      headers: {
-        ...getAuthHeader(),
-      },
-    })
-      .then((res) => res.text())
-      .then((text) => {
-        let data;
-        try {
-          data = JSON.parse(text);
-        } catch {
-          data = {};
-        }
-        const recs = Array.isArray(data.records) ? data.records : [];
+    if (!username) return;
+    fetch(`${baseUrl}/api/records/getRecord?username=${username}`)
+      .then((res) => res.json())
+      .then((data) => {
+        const recs = Array.isArray(data) ? data : [];
         setRecords(recs);
       })
       .catch(() => {});
@@ -52,23 +35,16 @@ export default function Home() {
   function createRecord() {
     const recordName = prompt("Perhiz kaydının ismi");
     if (!recordName) return;
-    const payload = {
-      records: [
-        {
-          recordName,
-          entries: [
-            // Yeni kayıt oluşturulurken entries boş başlatılır
-          ],
-        },
-      ],
-    };
-    fetch(`${baseUrl}/api/users/putHistory`, {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        ...getAuthHeader(),
-      },
-      body: JSON.stringify(payload),
+    fetch(`${baseUrl}/api/records/postRecord`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        username,
+        recordName,
+        foods: "",
+        data: "",
+        total: "",
+      }),
     })
       .then(() => fetchHistory())
       .catch(() => {});


### PR DESCRIPTION
## Summary
- switch to new `/api/records` endpoints
- preload existing record data in WordEditor
- autosave records to new backend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cf54b1b68832f8c53b87aa45c13b0