### PR TITLE
Fix new record flow and slugify names

### DIFF
--- a/src/app/[username]/[recordName]/page.jsx
+++ b/src/app/[username]/[recordName]/page.jsx
@@ -422,7 +422,10 @@ export default function WordEditorPage() {
       fetch(`${baseUrl}/api/records/getRecord/${params.username}`)
         .then(async (res) => {
           const text = await res.text();
-          if (!text) throw new Error("Kayıt bulunamadı veya boş yanıt.");
+          if (!text) {
+            setText("");
+            return;
+          }
           let arr;
           try {
             arr = JSON.parse(text);
@@ -437,7 +440,10 @@ export default function WordEditorPage() {
                   item.name === params.recordName
               )
             : null;
-          if (!record) throw new Error("Kayıt bulunamadı.");
+          if (!record) {
+            setText("");
+            return;
+          }
           setText(record.foods || record.data || "");
         })
         .catch((err) => {

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -1,14 +1,39 @@
 "use client";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import Button from "@mui/material/Button";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
 
+function slugify(text) {
+  const map = {
+    ç: "c",
+    ğ: "g",
+    ı: "i",
+    ö: "o",
+    ş: "s",
+    ü: "u",
+    Ç: "c",
+    Ğ: "g",
+    İ: "i",
+    Ö: "o",
+    Ş: "s",
+    Ü: "u",
+  };
+  return text
+    .split("")
+    .map((ch) => map[ch] || ch)
+    .join("")
+    .replace(/\s+/g, "-")
+    .toLowerCase();
+}
+
 export default function Home() {
   const [records, setRecords] = useState([]);
   const [username, setUsername] = useState("");
+  const router = useRouter();
   const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
 
   function fetchHistory() {
@@ -35,19 +60,23 @@ export default function Home() {
   function createRecord() {
     const recordName = prompt("Perhiz kaydının ismi");
     if (!recordName) return;
+    const slug = slugify(recordName);
     fetch(`${baseUrl}/api/records/postRecord`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         username,
-        name: recordName,
+        name: slug,
         foods: "",
         data: "",
         toplam: "",
       }),
       // credentials: "include", // Cookie göndermek isterseniz açabilirsiniz
     })
-      .then(() => fetchHistory())
+      .then(() => {
+        fetchHistory();
+        router.push(`/${username}/${encodeURIComponent(slug)}`);
+      })
       .catch(() => {});
   }
 


### PR DESCRIPTION
## Summary
- ensure newly created record slugs replace spaces with '-' and convert Turkish characters
- open the newly created record after creation
- gracefully handle missing record by opening an empty page instead of showing an error

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d1c7b8b44832fa7d96d9b51dbeca6